### PR TITLE
Fixes after updating to ROS2 Jazzy

### DIFF
--- a/trac_ik_kinematics/trac_ik_kinematics_plugin/include/trac_ik_kinematics_plugin/trac_ik_kinematics_plugin.h
+++ b/trac_ik_kinematics/trac_ik_kinematics_plugin/include/trac_ik_kinematics_plugin/trac_ik_kinematics_plugin.h
@@ -42,10 +42,10 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <moveit_msgs/msg/move_it_error_codes.hpp>
 
 // MoveIt
-#include <moveit/kinematics_base/kinematics_base.h>
+#include <moveit/kinematics_base/kinematics_base.hpp>
 // #include <moveit/kdl_kinematics_plugin/joint_mimic.hpp>
-#include <moveit/robot_model/robot_model.h>
-#include <moveit/robot_state/robot_state.h>
+#include <moveit/robot_model/robot_model.hpp>
+#include <moveit/robot_state/robot_state.hpp>
 
 #include <kdl/chain.hpp>
 #include <kdl/config.h>

--- a/trac_ik_kinematics/trac_ik_kinematics_plugin/src/trac_ik_kinematics_plugin.cpp
+++ b/trac_ik_kinematics/trac_ik_kinematics_plugin/src/trac_ik_kinematics_plugin.cpp
@@ -148,8 +148,13 @@ namespace trac_ik_kinematics_plugin
 
     // ###
 
-    lookupParam(node_, "position_only_ik", position_ik_, false);
-    lookupParam(node_, "solve_type", solve_type, std::string("Speed"));
+    // Declare parameters with default values
+    node_->declare_parameter("position_only_ik", false);
+    node_->declare_parameter("solve_type", std::string("Speed"));
+
+    // Get parameters
+    node_->get_parameter("position_only_ik", position_ik_);
+    node_->get_parameter("solve_type", solve_type);
 
     initialized_ = true;
     return true;
@@ -158,7 +163,7 @@ namespace trac_ik_kinematics_plugin
   int TRAC_IKKinematicsPlugin::getKDLSegmentIndex(const std::string &name) const
   {
     int i = 0;
-    while (i < (int)chain.getNrOfSegments())
+    while (i < static_cast<int>(chain.getNrOfSegments()))
     {
       if (chain.getSegment(i).getName() == name)
       {
@@ -317,8 +322,8 @@ namespace trac_ik_kinematics_plugin
                                                  std::vector<double> &solution,
                                                  const IKCallbackFn &solution_callback,
                                                  moveit_msgs::msg::MoveItErrorCodes &error_code,
-                                                 const std::vector<double> &consistency_limits,
-                                                 const kinematics::KinematicsQueryOptions &options) const
+                                                 const std::vector<double> & /*consistency_limits*/,
+                                                 const kinematics::KinematicsQueryOptions & /*options*/) const
   {
     RCLCPP_DEBUG_STREAM(LOGGER, "getPositionIK");
 
@@ -394,7 +399,7 @@ namespace trac_ik_kinematics_plugin
         }
         else
         {
-          RCLCPP_DEBUG(LOGGER, "Solution has error code %i", error_code);
+          RCLCPP_DEBUG(LOGGER, "Solution has error code %i", error_code.val);
           return false;
         }
       }

--- a/trac_ik_kinematics/trac_ik_kinematics_plugin/src/trac_ik_kinematics_plugin.cpp
+++ b/trac_ik_kinematics/trac_ik_kinematics_plugin/src/trac_ik_kinematics_plugin.cpp
@@ -148,13 +148,24 @@ namespace trac_ik_kinematics_plugin
 
     // ###
 
-    // Declare parameters with default values
-    node_->declare_parameter("position_only_ik", false);
-    node_->declare_parameter("solve_type", std::string("Speed"));
-
     // Get parameters
-    node_->get_parameter("position_only_ik", position_ik_);
-    node_->get_parameter("solve_type", solve_type);
+    if (node_->has_parameter("position_only_ik"))
+    {
+      node_->get_parameter("position_only_ik", position_ik_);
+    }
+    else
+    {
+      position_ik_ = false;  // Assign default value
+    }
+
+    if (node_->has_parameter("solve_type"))
+    {
+      node_->get_parameter("solve_type", solve_type);
+    }
+    else
+    {
+      solve_type = "Speed";  // Assign default value
+    }
 
     initialized_ = true;
     return true;


### PR DESCRIPTION
Fixes made for errors and warnings on `trac_ik_kinematics_plugin.h` and `trac_ik_kinematics_plugin.cpp` when updating from ROS2 humble to ROS2 Jazzy:

- Changed headers from `.h` to `.hpp`
- Removed the deprecated `lookupParam()` function and instead used `declare_parameter()` and `get_parameter()` functions from the `rclcpp::Node` class
- Replaced an old-style C cast (int) with a C++ `static_cast<int>()`
- Commented unused parameters in the function `TRAC_IKKinematicsPlugin::searchPositionIK`
- Access error code integer value using `error_code.val` to log it

Worked on these fixes along with @DatSpace 